### PR TITLE
Fix failing cabal build

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -1,5 +1,5 @@
 {-#LANGUAGE NamedFieldPuns #-}
-module PBook () where 
+module Main (main) where 
 
 import Network.Browser
 import Data.Maybe (fromJust)


### PR DESCRIPTION
`cabal build` kept complaning that `Main` module wasn't found and thus causing the build to not write the `pbook` executable to `dist`. This fixes the error.